### PR TITLE
Fix prometheus.Handler() function importation

### DIFF
--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/GrupaPracuj/iislog-prometheus-exporter/config"
 	"github.com/GrupaPracuj/iislog-prometheus-exporter/logging"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func ExportLogs(cfg *config.Config, logger *log.Logger) {
@@ -26,7 +26,7 @@ func ExportLogs(cfg *config.Config, logger *log.Logger) {
 	listenAddr := fmt.Sprintf("%s:%d", cfg.Listen.Address, cfg.Listen.Port)
 	logging.Info(logger, fmt.Sprintf("Running HTTP server on address %s", listenAddr))
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	go func() {
 		err := http.ListenAndServe(listenAddr, nil)


### PR DESCRIPTION
Importing prometheus.Handler() properly due 'github.com/GrupaPracuj/iislog-prometheus-exporter/lib
C:\Users\Administrator\go\src\github.com\GrupaPracuj\iislog-prometheus-exporter\lib\exporter.go:29:26: undefined: prometheus.Handler' error